### PR TITLE
Handling lazy-loaded dates better + % suffix for cloud cover

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -166,8 +166,9 @@ export default {
         dateAcquired: {
           label: "Date Acquired",
           sortable: true,
-          formatter: function(date) {
-            return new Date(date).toUTCString();
+          formatter: function(isoDate) {
+            const date = new Date(isoDate);
+            return !isNaN(date.getTime()) ? date.toUTCString() : "";
           }
         }
       },
@@ -432,7 +433,11 @@ export default {
         key = "title";
       }
 
-      if (typeof a[key] === "number" && typeof b[key] === "number") {
+      if (a[key] == null) {
+        return -1;
+      } else if (b[key] == null) {
+        return 1;
+      } else if (typeof a[key] === "number" && typeof b[key] === "number") {
         // If both compared fields are native numbers
         return a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0;
       } else {

--- a/src/lib/stac/dictionary.json
+++ b/src/lib/stac/dictionary.json
@@ -15,7 +15,8 @@
     "type": "date"
   },
   "eo:cloud_cover": {
-    "label": "Cloud cover"
+    "label": "Cloud cover",
+    "suffix": "%"
   },
   "eo:gsd": {
     "label": "Ground sample distance",


### PR DESCRIPTION
Handling lazy-loaded dates better for sorting and displaying (no more "toString() on undefined" errors).

Added % suffix for cloud cover.

(Sorry, your merge was quicker than my commits ;-) )